### PR TITLE
add bias ordering transform to improve identifiability in neural nets

### DIFF
--- a/paramax/wrappers.py
+++ b/paramax/wrappers.py
@@ -179,6 +179,21 @@ class WeightNormalization(AbstractUnwrappable[Array]):
         return self.scale * self.weight / weight_norms
 
 
+class BiasOrdering(AbstractUnwrappable[Array]):
+    """Applies bias ordering (http://bayesiandeeplearning.org/2017/papers/15.pdf).
+
+    Args:
+        bias: The (possibly wrapped) bias vector.
+    """
+
+    bias: Array | AbstractUnwrappable[Array]
+
+    def unwrap(self) -> Array:
+        first, log_diffs = self.bias[..., :1], self.bias[..., 1:]
+        first_and_diffs = jnp.concatenate([first, jnp.exp(log_diffs)], axis=-1)
+        return jnp.cumsum(first_and_diffs, axis=-1)
+
+
 def contains_unwrappables(pytree):
     """Check if a pytree contains unwrappables."""
 


### PR DESCRIPTION
Adds a reparameterization of a vector so that its elements are in increasing order. This is useful to apply to bias vectors in neural networks to remove degeneracy/multimodality in their likelihoods/posteriors induced by the label switching problem. See http://bayesiandeeplearning.org/2017/papers/15.pdf and https://num.pyro.ai/en/latest/_modules/numpyro/distributions/transforms.html#OrderedTransform.

I wasn't sure whether to add this to flowjax or paramax, as it looks you're planning to move the reparam functionality from flowjax to here.